### PR TITLE
fix: add @hono/node-server as explicit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "tanstack-hono",
       "dependencies": {
+        "@hono/node-server": "^1.9.0",
         "@tailwindcss/vite": "^4.1.13",
         "@tanstack/react-devtools": "^0.6.9",
         "@tanstack/react-query": "^5.89.0",
@@ -1249,7 +1250,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.0.tgz",
       "integrity": "sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check": "biome check"
   },
   "dependencies": {
+    "@hono/node-server": "^1.9.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-devtools": "^0.6.9",
     "@tanstack/react-query": "^5.89.0",


### PR DESCRIPTION
When not using npm, the dependency won't be resolved correctly.